### PR TITLE
include ofFileUtils.h in ofxHttpTypes (compatible to v0.12.0)

### DIFF
--- a/src/ofxHttpTypes.h
+++ b/src/ofxHttpTypes.h
@@ -14,6 +14,7 @@
 #define OFX_HTTP_POST 1
 
 #include "ofUtils.h"
+#include "ofFileUtils.h"
 
 struct ofxHttpForm{
 


### PR DESCRIPTION
Hello Arturoc,

I'm always enjoying using openFrameworks.

Today, I found a build error and am sending a pull request. I couldn't use ofToDataPath() in ofxHttpTypes.h, and it turned out that the cause was the change of the method's definition from ofUtils.h to ofFileUtils.h. Therefore, I've added #include "ofFileUtils.h".